### PR TITLE
Fix dark text hardly readable in dark mode

### DIFF
--- a/MaterialsLiveWallpaper/app/src/main/res/layout/activity_light_colors.xml
+++ b/MaterialsLiveWallpaper/app/src/main/res/layout/activity_light_colors.xml
@@ -23,7 +23,7 @@
 
             <TextView
                 android:text="@string/settings_lights_colors_load_sample"
-                android:textColor="#000"
+                android:textColor="@color/primaryTextColor"
                 android:textSize="16sp"
                 android:layout_margin="16dp"
                 android:layout_width="match_parent"
@@ -42,7 +42,7 @@
 
             <TextView
                 android:text="@string/settings_lights_colors_count"
-                android:textColor="#000"
+                android:textColor="@color/primaryTextColor"
                 android:textSize="16sp"
                 android:layout_margin="16dp"
                 android:layout_width="match_parent"

--- a/MaterialsLiveWallpaper/app/src/main/res/layout/light_colors_list_item.xml
+++ b/MaterialsLiveWallpaper/app/src/main/res/layout/light_colors_list_item.xml
@@ -9,7 +9,7 @@
     android:layout_height="wrap_content">
 
     <LinearLayout
-        android:background="#000"
+        android:background="@color/primaryTextColor"
         android:layout_margin="16dp"
         android:padding="1dp"
         android:orientation="vertical"
@@ -18,17 +18,17 @@
 
         <View
             android:id="@+id/color_preview"
-            android:background="#fff"
+            android:background="@color/primaryBackgroundColor"
             android:layout_width="24dp"
             android:layout_height="20dp" />
 
         <LinearLayout
-            android:background="#000"
+            android:background="@color/primaryTextColor"
             android:layout_width="24dp"
             android:layout_height="4dp">
             <View
                 android:id="@+id/intensity_preview"
-                android:background="#fff"
+                android:background="@color/primaryBackgroundColor"
                 android:layout_width="12dp"
                 android:layout_height="4dp" />
         </LinearLayout>
@@ -37,7 +37,7 @@
 
     <TextView
         android:id="@+id/label"
-        android:textColor="#000"
+        android:textColor="@color/primaryTextColor"
         android:textSize="16sp"
         android:layout_marginVertical="16dp"
         android:layout_marginEnd="16dp"

--- a/MaterialsLiveWallpaper/app/src/main/res/layout/light_colors_list_item.xml
+++ b/MaterialsLiveWallpaper/app/src/main/res/layout/light_colors_list_item.xml
@@ -9,7 +9,7 @@
     android:layout_height="wrap_content">
 
     <LinearLayout
-        android:background="@color/primaryTextColor"
+        android:background="#000"
         android:layout_margin="16dp"
         android:padding="1dp"
         android:orientation="vertical"
@@ -18,17 +18,17 @@
 
         <View
             android:id="@+id/color_preview"
-            android:background="@color/primaryBackgroundColor"
+            android:background="#fff"
             android:layout_width="24dp"
             android:layout_height="20dp" />
 
         <LinearLayout
-            android:background="@color/primaryTextColor"
+            android:background="#000"
             android:layout_width="24dp"
             android:layout_height="4dp">
             <View
                 android:id="@+id/intensity_preview"
-                android:background="@color/primaryBackgroundColor"
+                android:background="#fff"
                 android:layout_width="12dp"
                 android:layout_height="4dp" />
         </LinearLayout>

--- a/MaterialsLiveWallpaper/app/src/main/res/values-night/colors.xml
+++ b/MaterialsLiveWallpaper/app/src/main/res/values-night/colors.xml
@@ -5,5 +5,4 @@
     <color name="colorAccent">#00C0B8</color>
     <color name="grayTextColor">#AAAAAA</color>
     <color name="primaryTextColor">#FFFFFF</color>
-    <color name="primaryBackgroundColor">#000000</color>
 </resources>

--- a/MaterialsLiveWallpaper/app/src/main/res/values-night/colors.xml
+++ b/MaterialsLiveWallpaper/app/src/main/res/values-night/colors.xml
@@ -4,4 +4,6 @@
     <color name="colorPrimaryDark">#EE0056</color>
     <color name="colorAccent">#00C0B8</color>
     <color name="grayTextColor">#AAAAAA</color>
+    <color name="primaryTextColor">#FFFFFF</color>
+    <color name="primaryBackgroundColor">#000000</color>
 </resources>

--- a/MaterialsLiveWallpaper/app/src/main/res/values/colors.xml
+++ b/MaterialsLiveWallpaper/app/src/main/res/values/colors.xml
@@ -5,5 +5,4 @@
     <color name="colorAccent">#00DCC8</color>
     <color name="grayTextColor">#666666</color>
     <color name="primaryTextColor">#000000</color>
-    <color name="primaryBackgroundColor">#FFFFFF</color>
 </resources>

--- a/MaterialsLiveWallpaper/app/src/main/res/values/colors.xml
+++ b/MaterialsLiveWallpaper/app/src/main/res/values/colors.xml
@@ -4,4 +4,6 @@
     <color name="colorPrimaryDark">#FF0064</color>
     <color name="colorAccent">#00DCC8</color>
     <color name="grayTextColor">#666666</color>
+    <color name="primaryTextColor">#000000</color>
+    <color name="primaryBackgroundColor">#FFFFFF</color>
 </resources>


### PR DESCRIPTION
Fixes issue https://github.com/Reminimalism/MaterialsLiveWallpaper/issues/3.

After these changes the dark mode text looks like the attached screenshot. Light mode still looks the same.

<img width="540" height="1123" alt="Dark Text Fix" src="https://github.com/user-attachments/assets/cf550f4e-c465-423a-a5d8-7c410c297e79" />
